### PR TITLE
Fixed link in footer that leads to github issues page

### DIFF
--- a/client/components/footer.js
+++ b/client/components/footer.js
@@ -7,7 +7,7 @@ export default React.createClass({
     return (
       <footer className="footer txt-small txt-dimmed mb mt txt-center has-icon" role="contentinfo">
         <div className="container-fluid">
-          <a href="https://github.com/nearform/vidi-dashboard/issues" className="icon icon-bug icon-dimmed"></a>
+          <a href="https://github.com/nearform/concorda/issues" className="icon icon-bug icon-dimmed"></a>
           <p className="m0">{'MIT. Copyright © 2016. Concorda User Management'}</p>
         </div>
       </footer>


### PR DESCRIPTION
Link used to lead to vidi-dashboard github issues page, now it leads to concorda issues page. #81 
