### PR TITLE
Added pagination implementation on list user service. See #80

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "history": "1.17.x",
     "inert": "3.x.x",
     "influx": "4.0.x",
+    "jsonic": "0.2.2",
     "lodash": "3.10.1",
     "material-ui": "0.14.x",
     "moment": "2.11.x",

--- a/test/hapi.user.test.js
+++ b/test/hapi.user.test.js
@@ -92,10 +92,10 @@ suite('Hapi user suite tests ', () => {
     })
   })
 
+  let newName = 'newName'
   test('update another user test', (done) => {
     let url = '/api/user'
 
-    let newName = 'newName'
     user2.name = newName
     server.inject({
       url: url,
@@ -108,6 +108,110 @@ suite('Hapi user suite tests ', () => {
       Assert.equal(true, JSON.parse(res.payload).ok)
       Assert(JSON.parse(res.payload).data)
       Assert.equal(newName, JSON.parse(res.payload).data.name)
+
+      done()
+    })
+  })
+
+  test('list user test with name sorted ASC', (done) => {
+    let url = '/api/user?order={name: 1}'
+
+    server.inject({
+      url: url,
+      method: 'GET',
+      headers: { cookie: 'seneca-login=' + cookie }
+    }, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.equal(2, JSON.parse(res.payload).data.length)
+      Assert.equal(2, JSON.parse(res.payload).count)
+
+      Assert.equal(newName, JSON.parse(res.payload).data[0].name)
+
+      done()
+    })
+  })
+
+  test('list user test with name sorted DESC', (done) => {
+    let url = '/api/user?order={name: -1}'
+
+    server.inject({
+      url: url,
+      method: 'GET',
+      headers: { cookie: 'seneca-login=' + cookie }
+    }, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.equal(2, JSON.parse(res.payload).data.length)
+      Assert.equal(2, JSON.parse(res.payload).count)
+
+      Assert.equal(user.name, JSON.parse(res.payload).data[0].name)
+
+      done()
+    })
+  })
+
+  test('list user test with name sorted DESC and limit 1', (done) => {
+    let url = '/api/user?order={name: -1}&limit=1'
+
+    server.inject({
+      url: url,
+      method: 'GET',
+      headers: { cookie: 'seneca-login=' + cookie }
+    }, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.equal(1, JSON.parse(res.payload).data.length)
+      Assert.equal(1, JSON.parse(res.payload).count)
+
+      Assert.equal(user.name, JSON.parse(res.payload).data[0].name)
+
+      done()
+    })
+  })
+
+  test('list user test with name sorted DESC and limit 1 and skip 1', (done) => {
+    let url = '/api/user?order={name: -1}&limit=1&skip=1'
+
+    server.inject({
+      url: url,
+      method: 'GET',
+      headers: { cookie: 'seneca-login=' + cookie }
+    }, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.equal(1, JSON.parse(res.payload).data.length)
+      Assert.equal(1, JSON.parse(res.payload).count)
+
+      Assert.equal(newName, JSON.parse(res.payload).data[0].name)
+
+      done()
+    })
+  })
+
+  test('list user test with name sorted DESC and limit 1 and skip 10', (done) => {
+    let url = '/api/user?order={name: -1}&limit=1&skip=10'
+
+    server.inject({
+      url: url,
+      method: 'GET',
+      headers: { cookie: 'seneca-login=' + cookie }
+    }, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.equal(0, JSON.parse(res.payload).data.length)
+      Assert.equal(0, JSON.parse(res.payload).count)
+
+      done()
+    })
+  })
+
+  test('list user test with name sorted DESC and limit 1 and skip 10', (done) => {
+    let url = '/api/user?order={name: -1}&limit=1&skip=10'
+
+    server.inject({
+      url: url,
+      method: 'GET',
+      headers: { cookie: 'seneca-login=' + cookie }
+    }, function (res) {
+      Assert.equal(200, res.statusCode)
+      Assert.equal(0, JSON.parse(res.payload).data.length)
+      Assert.equal(0, JSON.parse(res.payload).count)
 
       done()
     })

--- a/test/hapi.user.test.js
+++ b/test/hapi.user.test.js
@@ -82,7 +82,7 @@ suite('Hapi user suite tests ', () => {
     }, (res) => {
       Assert.equal(200, res.statusCode)
 
-      Assert.equal(false, JSON.parse(res.payload).err)
+      Assert.equal(true, JSON.parse(res.payload).ok)
       Assert(JSON.parse(res.payload).data)
       Assert.equal(user2.name, JSON.parse(res.payload).data.name)
 
@@ -105,7 +105,7 @@ suite('Hapi user suite tests ', () => {
     }, (res) => {
       Assert.equal(200, res.statusCode)
 
-      Assert.equal(false, JSON.parse(res.payload).err)
+      Assert.equal(true, JSON.parse(res.payload).ok)
       Assert(JSON.parse(res.payload).data)
       Assert.equal(newName, JSON.parse(res.payload).data.name)
 


### PR DESCRIPTION
it will accept something like this:

/api/user?order={name: -1}&limit=1&skip=10

where 
- order = a JSON for order criteria using the Mongo syntax
- limit - number of items to return
- skip - number of items to skip

The search features for seneca-mem-store seems to be missing so I cannot implement search, we should first decide the store to be used.
